### PR TITLE
Improve validation and comparison of version ranges

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -56,9 +56,6 @@ function cleanVersion(version) {
 function checkNpmDependency(dep, version, verbose) {
   verify.unemptyString(version, 'missing declared version for ' + dep);
 
-  var declaredVersion = cleanVersion(version);
-  check.verify.string(declaredVersion, 'could not clean up version ' + version);
-
   var filename = join(process.cwd(), 'node_modules', dep, 'package.json');
   var installedDep = getPackage(filename);
 
@@ -78,10 +75,10 @@ function checkNpmDependency(dep, version, verbose) {
   }
 
   if (verbose) {
-    console.log(dep, 'needed', declaredVersion, 'installed', installedVersion);
+    console.log(dep, 'needed', version, 'installed', installedVersion);
   }
-  if (semver.lt(installedVersion, declaredVersion)) {
-    console.error('ERROR:', dep, declaredVersion,
+  if (semver.ltr(installedVersion, version)) {
+    console.error('ERROR:', dep, version,
       'needed, but found', installedVersion);
     return false;
   }
@@ -91,9 +88,6 @@ function checkNpmDependency(dep, version, verbose) {
 
 function checkBowerDependency(dep, version, verbose) {
   verify.unemptyString(version, 'missing declared version for ' + dep);
-
-  var declaredVersion = cleanVersion(version);
-  check.verify.string(declaredVersion, 'could not clean up version ' + version);
 
   var folder = join(process.cwd(), 'bower_components', dep);
   if (!exists(folder)) {
@@ -129,10 +123,10 @@ function checkBowerDependency(dep, version, verbose) {
   }
 
   if (verbose) {
-    console.log(dep, 'needed', declaredVersion, 'installed', installedVersion);
+    console.log(dep, 'needed', version, 'installed', installedVersion);
   }
-  if (semver.lt(installedVersion, declaredVersion)) {
-    console.error('ERROR:', dep, declaredVersion,
+  if (semver.ltr(installedVersion, version)) {
+    console.error('ERROR:', dep, version,
       'needed, but found', installedVersion);
     return false;
   }


### PR DESCRIPTION
The semver module makes a distinction between a "version" as specified in the version field of package.json, and a "version range" which is used to specify dependency versions in npm/bower. The former is very restrictive, while the latter allows for version strings such as ">=1.0.1", "1.0.x", etc.

The semver.clean function only applies to a _version_, rather than a _version range_, and would thus fail for many valid dependency version range strings (such as the ones mentioned above). Additionally, the semver.**lt** function compares a version to another version, while semver.**ltr** compares a version to a version _range_.

The code in this pull request treats dependency versions as _version ranges_ rather than _versions_.
