### PR TITLE
Support file prefix

### DIFF
--- a/src/is-supported-version-format.js
+++ b/src/is-supported-version-format.js
@@ -2,18 +2,18 @@ var check = require('check-types');
 var verify = check.verify;
 
 var gitAt = /^git@/;
-var startsWithGit = /^git:/;
+var startsWithPrefix = /^(git|github|file):/;
 
-function isGitVersion(str) {
-  return gitAt.test(str) || startsWithGit.test(str);
+function isGitAtVersion(str) {
+  return gitAt.test(str);
 }
 
 function isVersionKeyword(str) {
   return str === '*' || str === 'latest';
 }
 
-function isGithubPackage(str) {
-  return /^github:/.test(str);
+function isPrefixed(str) {
+  return startsWithPrefix.test(str);
 }
 
 function isSupportedVersionFormat(version) {
@@ -21,9 +21,9 @@ function isSupportedVersionFormat(version) {
 
   return !check.webUrl(version) &&
     !check.gitUrl(version) &&
-    !isGitVersion(version) &&
+    !isGitAtVersion(version) &&
     !isVersionKeyword(version) &&
-    !isGithubPackage(version);
+    !isPrefixed(version);
 }
 
 module.exports = isSupportedVersionFormat;

--- a/src/test/supported-version.coffee
+++ b/src/test/supported-version.coffee
@@ -10,4 +10,6 @@ gt.test 'regular versions', ->
 gt.test 'unsupported urls', ->
   gt.ok !isSupported('http://somewhere/repo'), 'http'
   gt.ok !isSupported('git@github.com:bahmutov/angular-minicolors.git'), 'git@'
-  gt.ok !isSupported('git://gh.com/foo/bar#30030')
+  gt.ok !isSupported('git://gh.com/foo/bar#30030'), 'git'
+  gt.ok !isSupported('github:jstrace/bars'), 'github'
+  gt.ok !isSupported('file:./dummy'), 'file'

--- a/test/dummy/package.json
+++ b/test/dummy/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dummy",
+  "version": "0.0.1",
+  "description": "Dummy module for testing 'file:' version"
+}

--- a/test/e2e.coffee
+++ b/test/e2e.coffee
@@ -33,6 +33,14 @@ gt.async 'test version with github version', ->
   gt.exec 'node', args.concat(relative('./package-with-github.json')), 0,
     'this handles github: version string'
 
+gt.async 'test version with local file path', ->
+  gt.exec 'node', args.concat(relative('./package-with-file.json')), 0,
+    'this handles file: version string'
+
+gt.async 'test version with url', ->
+  gt.exec 'node', args.concat(relative('./package-with-url.json')), 0,
+    'this handles url string'
+
 gt.async 'test non-existing file', ->
   gt.exec 'node', args.concat(relative('./does-not-exist.json')), ERROR_EXIT_CODE,
     'package file does not exist'

--- a/test/package-with-file.json
+++ b/test/package-with-file.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-package",
+  "description": "One dependency has local file path",
+  "version": "0.0.1",
+  "dependencies": {
+    "dummy": "file:./dummy"
+  }
+}

--- a/test/package-with-url.json
+++ b/test/package-with-url.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-package",
+  "description": "One dependency has url",
+  "version": "0.0.1",
+  "dependencies": {
+    "bars": "https://github.com/jstrace/bars/archive/1.2.2.tar.gz"
+  }
+}


### PR DESCRIPTION
I added a check to `is-supported-version-format.js` for the `file:` prefix and added a corresponding test. I also added a test for url versions since there wasn't a test for that one yet.
